### PR TITLE
133 bug new tabs dont create separate nlogviewer usercontrol feature setting to control tab reuse behavior

### DIFF
--- a/app/Sentinel.NLogViewer.App/App.xaml.cs
+++ b/app/Sentinel.NLogViewer.App/App.xaml.cs
@@ -92,6 +92,6 @@ namespace Sentinel.NLogViewer.App
         /// <summary>
         /// Gets the service provider for dependency injection
         /// </summary>
-        public static IServiceProvider ServiceProvider => ((App)Current)._host?.Services;
+        public static IServiceProvider? ServiceProvider => (Current as App)?._host?.Services;
     }
 }

--- a/app/Sentinel.NLogViewer.App/AttachedProperties/TabContent.cs
+++ b/app/Sentinel.NLogViewer.App/AttachedProperties/TabContent.cs
@@ -1,0 +1,282 @@
+﻿// TabContent.cs, version 1.2
+// The code in this file is Copyright (c) Ivan Krivyakov
+// See http://www.ikriv.com/legal.php for more information
+// https://www.codeproject.com/articles/WPF-TabControl-Turning-Off-Tab-Virtualization#comments-section
+
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace Sentinel.NLogViewer.App.AttachedProperties
+{
+	/// <summary>
+	/// Attached properties for persistent tab control
+	/// </summary>
+	/// <remarks>By default WPF TabControl bound to an ItemsSource destroys visual state of invisible tabs. 
+	/// Set ikriv:TabContent.IsCached="True" to preserve visual state of each tab.
+	/// </remarks>
+	public static class TabContent
+	{
+		public static bool GetIsCached(DependencyObject obj)
+		{
+			return (bool)obj.GetValue(IsCachedProperty);
+		}
+
+		public static void SetIsCached(DependencyObject obj, bool value)
+		{
+			obj.SetValue(IsCachedProperty, value);
+		}
+
+		/// <summary>
+		/// Controls whether tab content is cached or not
+		/// </summary>
+		/// <remarks>When TabContent.IsCached is true, visual state of each tab is preserved (cached), even when the tab is hidden</remarks>
+		public static readonly DependencyProperty IsCachedProperty =
+			DependencyProperty.RegisterAttached("IsCached", typeof(bool), typeof(TabContent), new UIPropertyMetadata(false, OnIsCachedChanged));
+
+
+		public static DataTemplate GetTemplate(DependencyObject obj)
+		{
+			return (DataTemplate)obj.GetValue(TemplateProperty);
+		}
+
+		public static void SetTemplate(DependencyObject obj, DataTemplate value)
+		{
+			obj.SetValue(TemplateProperty, value);
+		}
+
+		/// <summary>
+		/// Used instead of TabControl.ContentTemplate for cached tabs
+		/// </summary>
+		public static readonly DependencyProperty TemplateProperty =
+			DependencyProperty.RegisterAttached("Template", typeof(DataTemplate), typeof(TabContent), new UIPropertyMetadata(null));
+
+
+		public static DataTemplateSelector GetTemplateSelector(DependencyObject obj)
+		{
+			return (DataTemplateSelector)obj.GetValue(TemplateSelectorProperty);
+		}
+
+		public static void SetTemplateSelector(DependencyObject obj, DataTemplateSelector value)
+		{
+			obj.SetValue(TemplateSelectorProperty, value);
+		}
+
+		/// <summary>
+		/// Used instead of TabControl.ContentTemplateSelector for cached tabs
+		/// </summary>
+		public static readonly DependencyProperty TemplateSelectorProperty =
+			DependencyProperty.RegisterAttached("TemplateSelector", typeof(DataTemplateSelector), typeof(TabContent), new UIPropertyMetadata(null));
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static TabControl GetInternalTabControl(DependencyObject obj)
+		{
+			return (TabControl)obj.GetValue(InternalTabControlProperty);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetInternalTabControl(DependencyObject obj, TabControl value)
+		{
+			obj.SetValue(InternalTabControlProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for InternalTabControl.  This enables animation, styling, binding, etc...
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static readonly DependencyProperty InternalTabControlProperty =
+			DependencyProperty.RegisterAttached("InternalTabControl", typeof(TabControl), typeof(TabContent), new UIPropertyMetadata(null, OnInternalTabControlChanged));
+
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static ContentControl GetInternalCachedContent(DependencyObject obj)
+		{
+			return (ContentControl)obj.GetValue(InternalCachedContentProperty);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetInternalCachedContent(DependencyObject obj, ContentControl value)
+		{
+			obj.SetValue(InternalCachedContentProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for InternalCachedContent.  This enables animation, styling, binding, etc...
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static readonly DependencyProperty InternalCachedContentProperty =
+			DependencyProperty.RegisterAttached("InternalCachedContent", typeof(ContentControl), typeof(TabContent), new UIPropertyMetadata(null));
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static object GetInternalContentManager(DependencyObject obj)
+		{
+			return (object)obj.GetValue(InternalContentManagerProperty);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetInternalContentManager(DependencyObject obj, object value)
+		{
+			obj.SetValue(InternalContentManagerProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for InternalContentManager.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty InternalContentManagerProperty =
+			DependencyProperty.RegisterAttached("InternalContentManager", typeof(object), typeof(TabContent), new UIPropertyMetadata(null));
+
+		private static void OnIsCachedChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
+		{
+			if (obj == null) return;
+
+			var tabControl = obj as TabControl;
+			if (tabControl == null)
+			{
+				throw new InvalidOperationException("Cannot set TabContent.IsCached on object of type " + args.NewValue.GetType().Name +
+					". Only objects of type TabControl can have TabContent.IsCached property.");
+			}
+
+			bool newValue = (bool)args.NewValue;
+
+			if (!newValue)
+			{
+				if (args.OldValue != null && ((bool)args.OldValue))
+				{
+					throw new NotImplementedException("Cannot change TabContent.IsCached from True to False. Turning tab caching off is not implemented");
+				}
+
+				return;
+			}
+
+			EnsureContentTemplateIsNull(tabControl);
+			tabControl.ContentTemplate = CreateContentTemplate();
+			EnsureContentTemplateIsNotModified(tabControl);
+		}
+
+		private static DataTemplate CreateContentTemplate()
+		{
+			const string xaml =
+				"<DataTemplate><Border b:TabContent.InternalTabControl=\"{Binding RelativeSource={RelativeSource AncestorType=TabControl}}\" /></DataTemplate>";
+
+			var context = new ParserContext();
+
+			context.XamlTypeMapper = new XamlTypeMapper(new string[0]);
+			context.XamlTypeMapper.AddMappingProcessingInstruction("b", typeof(TabContent).Namespace, typeof(TabContent).Assembly.FullName);
+
+			context.XmlnsDictionary.Add("", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+			context.XmlnsDictionary.Add("b", "b");
+
+			var template = (DataTemplate)XamlReader.Parse(xaml, context);
+			return template;
+		}
+
+		private static void OnInternalTabControlChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
+		{
+			if (obj == null) return;
+			var container = obj as Decorator;
+
+			if (container == null)
+			{
+				var message = "Cannot set TabContent.InternalTabControl on object of type " + obj.GetType().Name +
+					". Only controls that derive from Decorator, such as Border can have a TabContent.InternalTabControl.";
+				throw new InvalidOperationException(message);
+			}
+
+			if (args.NewValue == null) return;
+			if (!(args.NewValue is TabControl))
+			{
+				throw new InvalidOperationException("Value of TabContent.InternalTabControl cannot be of type " + args.NewValue.GetType().Name + ", it must be of type TabControl");
+			}
+
+			var tabControl = (TabControl)args.NewValue;
+			var contentManager = GetContentManager(tabControl, container);
+			contentManager.UpdateSelectedTab();
+		}
+
+		private static ContentManager GetContentManager(TabControl tabControl, Decorator container)
+		{
+			var contentManager = (ContentManager)GetInternalContentManager(tabControl);
+			if (contentManager != null)
+			{
+				/*
+                 * Content manager already exists for the tab control. This means that tab content template is applied 
+                 * again, and new instance of the Border control (container) has been created. The old container 
+                 * referenced by the content manager is no longer visible and needs to be replaced
+                 */
+				contentManager.ReplaceContainer(container);
+			}
+			else
+			{
+				// create content manager for the first time
+				contentManager = new ContentManager(tabControl, container);
+				SetInternalContentManager(tabControl, contentManager);
+			}
+
+			return contentManager;
+		}
+
+		private static void EnsureContentTemplateIsNull(TabControl tabControl)
+		{
+			if (tabControl.ContentTemplate != null)
+			{
+				throw new InvalidOperationException("TabControl.ContentTemplate value is not null. If TabContent.IsCached is True, use TabContent.Template instead of ContentTemplate");
+			}
+		}
+
+		private static void EnsureContentTemplateIsNotModified(TabControl tabControl)
+		{
+			var descriptor = DependencyPropertyDescriptor.FromProperty(TabControl.ContentTemplateProperty, typeof(TabControl));
+			descriptor.AddValueChanged(tabControl, (sender, args) =>
+			{
+				throw new InvalidOperationException("Cannot assign to TabControl.ContentTemplate when TabContent.IsCached is True. Use TabContent.Template instead");
+			});
+		}
+
+		public class ContentManager
+		{
+			TabControl _tabControl;
+			Decorator _border;
+
+			public ContentManager(TabControl tabControl, Decorator border)
+			{
+				_tabControl = tabControl;
+				_border = border;
+				_tabControl.SelectionChanged += (sender, args) => { UpdateSelectedTab(); };
+			}
+
+			public void ReplaceContainer(Decorator newBorder)
+			{
+				if (Object.ReferenceEquals(_border, newBorder)) return;
+
+				_border.Child = null; // detach any tab content that old border may hold
+				_border = newBorder;
+			}
+
+			public void UpdateSelectedTab()
+			{
+				_border.Child = GetCurrentContent();
+			}
+
+			private ContentControl GetCurrentContent()
+			{
+				var item = _tabControl.SelectedItem;
+				if (item == null) return null;
+
+				var tabItem = _tabControl.ItemContainerGenerator.ContainerFromItem(item);
+				if (tabItem == null) return null;
+
+				var cachedContent = TabContent.GetInternalCachedContent(tabItem);
+				if (cachedContent == null)
+				{
+					cachedContent = new ContentControl
+					{
+						DataContext = item,
+						ContentTemplate = TabContent.GetTemplate(_tabControl),
+						ContentTemplateSelector = TabContent.GetTemplateSelector(_tabControl)
+					};
+
+					cachedContent.SetBinding(ContentControl.ContentProperty, new Binding());
+					TabContent.SetInternalCachedContent(tabItem, cachedContent);
+				}
+
+				return cachedContent;
+			}
+		}
+	}
+}

--- a/app/Sentinel.NLogViewer.App/MainWindow.xaml
+++ b/app/Sentinel.NLogViewer.App/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:dj="clr-namespace:Sentinel.NLogViewer.Wpf;assembly=Sentinel.NLogViewer.Wpf"
         xmlns:viewModels="clr-namespace:Sentinel.NLogViewer.App.ViewModels"
         xmlns:helpers="clr-namespace:Sentinel.NLogViewer.App.Helpers"
+        xmlns:models="clr-namespace:Sentinel.NLogViewer.App.Models"
         mc:Ignorable="d" 
         Title="NLogViewer Client Application" 
         Height="600" 
@@ -75,8 +76,8 @@
                 </DataTemplate>
             </TabControl.ItemTemplate>
             <TabControl.ContentTemplate>
-                <DataTemplate>
-                    <dj:NLogViewer/>
+                <DataTemplate DataType="models:LogTabViewModel">
+                    <dj:NLogViewer ItemsSource="{Binding Path=LogEventInfos, Mode=OneWay}" />
                 </DataTemplate>
             </TabControl.ContentTemplate>
         </TabControl>

--- a/app/Sentinel.NLogViewer.App/MainWindow.xaml
+++ b/app/Sentinel.NLogViewer.App/MainWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:viewModels="clr-namespace:Sentinel.NLogViewer.App.ViewModels"
         xmlns:helpers="clr-namespace:Sentinel.NLogViewer.App.Helpers"
         xmlns:models="clr-namespace:Sentinel.NLogViewer.App.Models"
+        xmlns:attachedProperties="clr-namespace:Sentinel.NLogViewer.App.AttachedProperties"
         mc:Ignorable="d" 
         Title="NLogViewer Client Application" 
         Height="600" 
@@ -14,6 +15,12 @@
         WindowStartupLocation="CenterScreen"
         d:DataContext="{d:DesignInstance viewModels:MainViewModel}">
     <Grid>
+        <Grid.Resources>
+            <DataTemplate x:Key="TabControlContentTemplate" DataType="models:LogTabViewModel">
+                <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
+                <dj:NLogViewer ItemsSource="{Binding DataContext.LogEventInfos, Mode=OneWay, RelativeSource={RelativeSource AncestorType=ContentPresenter}}" />
+            </DataTemplate>
+        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -59,10 +66,11 @@
         </ToolBar>
         
         <!-- Main Content: TabControl with NLogViewers -->
-        <TabControl x:Name="LogTabsControl" 
-                    Grid.Row="1" 
+        <TabControl Grid.Row="1" 
                     ItemsSource="{Binding LogTabs}"
-                    SelectedItem="{Binding SelectedTab}">
+                    SelectedItem="{Binding SelectedTab}"
+                    attachedProperties:TabContent.IsCached="True"
+                    attachedProperties:TabContent.Template="{StaticResource TabControlContentTemplate}">
             <TabControl.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">
@@ -75,11 +83,6 @@
                     </StackPanel>
                 </DataTemplate>
             </TabControl.ItemTemplate>
-            <TabControl.ContentTemplate>
-                <DataTemplate DataType="models:LogTabViewModel" x:Shared="False">
-                    <dj:NLogViewer ItemsSource="{Binding DataContext.LogEventInfos, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWay}" />
-                </DataTemplate>
-            </TabControl.ContentTemplate>
         </TabControl>
         
         <!-- Status Bar -->
@@ -112,31 +115,32 @@
         </StatusBar>
         
         <!-- Loading Overlay -->
-        <Grid Grid.RowSpan="3" 
-              Background="#80000000" 
-              Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
-              Panel.ZIndex="1000">
-            <Border Background="White" 
-                    CornerRadius="10" 
-                    Padding="30"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    MinWidth="300">
-                <StackPanel>
-                    <TextBlock Text="Loading File..." 
-                               FontSize="18" 
-                               FontWeight="Bold"
-                               HorizontalAlignment="Center"
-                               Margin="0,0,0,20"/>
-                    <ProgressBar IsIndeterminate="True" 
-                                 Height="20" 
-                                 Margin="0,0,0,10"/>
-                    <TextBlock Text="{Binding LoadingProgress}" 
-                               HorizontalAlignment="Center"
-                               TextAlignment="Center"
-                               Foreground="Gray"/>
-                </StackPanel>
-            </Border>
+        <Grid Grid.Row="0" Grid.RowSpan="3" d:Visibility="Collapsed">
+            <Grid Background="#80000000" 
+                  Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                  Panel.ZIndex="1000">
+                <Border Background="White" 
+                        CornerRadius="10" 
+                        Padding="30"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        MinWidth="300">
+                    <StackPanel>
+                        <TextBlock Text="Loading File..." 
+                                   FontSize="18" 
+                                   FontWeight="Bold"
+                                   HorizontalAlignment="Center"
+                                   Margin="0,0,0,20"/>
+                        <ProgressBar IsIndeterminate="True" 
+                                     Height="20" 
+                                     Margin="0,0,0,10"/>
+                        <TextBlock Text="{Binding LoadingProgress}" 
+                                   HorizontalAlignment="Center"
+                                   TextAlignment="Center"
+                                   Foreground="Gray"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Grid>
     </Grid>
 </Window>

--- a/app/Sentinel.NLogViewer.App/MainWindow.xaml
+++ b/app/Sentinel.NLogViewer.App/MainWindow.xaml
@@ -76,8 +76,8 @@
                 </DataTemplate>
             </TabControl.ItemTemplate>
             <TabControl.ContentTemplate>
-                <DataTemplate DataType="models:LogTabViewModel">
-                    <dj:NLogViewer ItemsSource="{Binding Path=LogEventInfos, Mode=OneWay}" />
+                <DataTemplate DataType="models:LogTabViewModel" x:Shared="False">
+                    <dj:NLogViewer ItemsSource="{Binding DataContext.LogEventInfos, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWay}" />
                 </DataTemplate>
             </TabControl.ContentTemplate>
         </TabControl>

--- a/app/Sentinel.NLogViewer.App/Models/LogTabViewModel.cs
+++ b/app/Sentinel.NLogViewer.App/Models/LogTabViewModel.cs
@@ -1,5 +1,7 @@
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using NLog;
 
 namespace Sentinel.NLogViewer.App.Models
 {
@@ -65,7 +67,9 @@ namespace Sentinel.NLogViewer.App.Models
             }
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
+        public ObservableCollection<LogEventInfo> LogEventInfos { get; } = new();
+
+		public event PropertyChangedEventHandler? PropertyChanged;
 
         protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {

--- a/ui/Sentinel.NLogViewer.Wpf/NLogViewer.xaml.cs
+++ b/ui/Sentinel.NLogViewer.Wpf/NLogViewer.xaml.cs
@@ -533,6 +533,57 @@ namespace Sentinel.NLogViewer.Wpf
             typeof(CollectionViewSource), typeof(NLogViewer), new PropertyMetadata(null));
         
         /// <summary>
+        /// External items source for log events. When set, the control will use this collection instead of the internal cache target.
+        /// If this is set, StartListen() will not be called automatically and the control will not subscribe to CacheTarget.
+        /// </summary>
+        [Category("NLogViewer")]
+        [Browsable(true)]
+        [Description("External collection of LogEventInfo items. When set, the control uses this instead of CacheTarget.")]
+        public ObservableCollection<LogEventInfo> ItemsSource
+        {
+            get => (ObservableCollection<LogEventInfo>)GetValue(ItemsSourceProperty);
+            set => SetValue(ItemsSourceProperty, value);
+        }
+
+        /// <summary>
+        /// The <see cref="ItemsSource"/> DependencyProperty.
+        /// </summary>
+        public static readonly DependencyProperty ItemsSourceProperty = 
+            DependencyProperty.Register(nameof(ItemsSource), typeof(ObservableCollection<LogEventInfo>), typeof(NLogViewer), 
+                new PropertyMetadata(null, OnItemsSourceChanged));
+
+        private static void OnItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is NLogViewer instance)
+            {
+                instance.OnItemsSourceChanged(e.OldValue as ObservableCollection<LogEventInfo>, 
+                    e.NewValue as ObservableCollection<LogEventInfo>);
+            }
+        }
+
+        private void OnItemsSourceChanged(ObservableCollection<LogEventInfo> oldValue, ObservableCollection<LogEventInfo> newValue)
+        {
+            // Update the CollectionViewSource to point to the new source
+            if (newValue != null)
+            {
+                LogEvents = new CollectionViewSource { Source = newValue };
+                UpdateFilter();
+                
+                // If using external source, stop listening to cache target
+                if (_isListening)
+                {
+                    StopListen();
+                }
+            }
+            else
+            {
+                // Fall back to internal collection
+                LogEvents = new CollectionViewSource { Source = _LogEventInfos };
+                UpdateFilter();
+            }
+        }
+        
+        /// <summary>
         /// Automatically scroll to the newest entry
         /// </summary>
         [Category("NLogViewerControls")]
@@ -755,6 +806,10 @@ namespace Sentinel.NLogViewer.Wpf
         {
             if (d is NLogViewer viewer && !DesignerProperties.GetIsInDesignMode(viewer))
             {
+                // Only handle pause/resume if not using external ItemsSource
+                if (viewer.ItemsSource != null)
+                    return;
+
                 if ((bool)e.NewValue)
                 {
                     // Pause: Stop listening for better performance
@@ -1463,9 +1518,14 @@ namespace Sentinel.NLogViewer.Wpf
         /// Starts listening for log events by subscribing to the cache target.
         /// This method should be called when the control needs to resume listening for logs,
         /// such as when undocking from a docking system or when the window loads again.
+        /// Note: This method will not start listening if ItemsSource is set (external mode).
         /// </summary>
         public void StartListen()
         {
+            // Don't start listening if using external ItemsSource
+            if (ItemsSource != null)
+                return;
+
             if (_isListening || DesignerProperties.GetIsInDesignMode(this))
                 return;
 
@@ -1553,13 +1613,26 @@ namespace Sentinel.NLogViewer.Wpf
             if (DesignerProperties.GetIsInDesignMode(this))
                 return;
 
+            // Initialize with internal collection (will be overridden if ItemsSource is set)
             LogEvents = new CollectionViewSource {Source = _LogEventInfos};
             ActiveSearchTerms = new ObservableCollection<SearchTerm>();
             UpdateFilter(); // Initialize filter
             
             Loaded += _OnLoaded;
             Unloaded += _OnUnloaded;
-            ClearCommand = new RelayCommand(_LogEventInfos.Clear);
+            
+            // ClearCommand: Only clear internal collection if not using external ItemsSource
+            ClearCommand = new RelayCommand(() => 
+            {
+                if (ItemsSource == null)
+                {
+                    _LogEventInfos.Clear();
+                }
+                else
+                {
+                    ItemsSource.Clear();
+                }
+            });
             AddSearchTermCommand = new RelayCommand(AddSearchTerm);
             ClearAllSearchTermsCommand = new RelayCommand(ClearAllSearchTerms);
             RemoveSearchTermCommand = new RelayCommand<SearchTerm>(RemoveSearchTerm);
@@ -1626,8 +1699,11 @@ namespace Sentinel.NLogViewer.Wpf
                 UpdateColumnVisibility();
             }
             
-            // Start listening for log events
-            StartListen();
+            // Start listening for log events only if not using external ItemsSource
+            if (ItemsSource == null)
+            {
+                StartListen();
+            }
         }
 
         #endregion


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce external ItemsSource to NLogViewer and per-tab cached TabControl content; refactor log flow to batch/group events and bind directly to per-tab collections with improved design-time resource lookup.
> 
> - **UI/Controls**:
>   - **NLogViewer** (`ui/Sentinel.NLogViewer.Wpf/NLogViewer.xaml.cs`): add `ItemsSource` DP to accept external `ObservableCollection<LogEventInfo>`; update `StartListen`, `Pause`, `ClearCommand`, and load behavior to no-op when external source is used; initialize `LogEvents` accordingly.
>   - **Tab Content Caching**: add `AttachedProperties/TabContent.cs` and enable cached tabs in `MainWindow.xaml` with `attachedProperties:TabContent.IsCached="True"` and a `TabControl` content `DataTemplate` that binds `NLogViewer.ItemsSource` to each tab’s `LogEventInfos`.
> - **App/ViewModels**:
>   - **MainViewModel**: buffer UDP log events, group by `AppInfo.Id`, and batch-add to the corresponding tab’s `LogEventInfos`; create tabs on-demand; update file parsing to add logs directly to the collection in batches (remove `CacheTarget` usage).
>   - **LogTabViewModel**: add `ObservableCollection<LogEventInfo> LogEventInfos` for per-tab data binding.
>   - **App.xaml.cs**: make `ServiceProvider` nullable-safe.
> - **Localization**:
>   - **ResourceExtension**: support design-time RESX loading via `ResourceManager` with culture handling; retain runtime DI fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac61514c66d94cd34f5781eaaa380098ed8c789c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->