### PR TITLE
feat(debug): add shared test-logging library, auto-start option, and …

### DIFF
--- a/NLogViewer.sln
+++ b/NLogViewer.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.0.11222.15
@@ -12,6 +12,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sentinel.NLogViewer.Wpf.MaterialDesign.TestApp", "testapp\Sentinel.NLogViewer.Wpf.MaterialDesign.TestApp\Sentinel.NLogViewer.Wpf.MaterialDesign.TestApp.csproj", "{D1CF3283-A165-477B-A08A-BEBFCD7A7712}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sentinel.NLogViewer.App", "app\Sentinel.NLogViewer.App\Sentinel.NLogViewer.App.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F123456789AB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sentinel.NLogViewer.TestLogging", "app\Sentinel.NLogViewer.TestLogging\Sentinel.NLogViewer.TestLogging.csproj", "{E5F6A7B8-C9D0-1234-EF56-789ABCDE0123}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sentinel.NLogViewer.App.TestApp", "testapp\Sentinel.NLogViewer.App.TestApp\Sentinel.NLogViewer.App.TestApp.csproj", "{C3D4E5F6-A7B8-9012-CDEF-123456789ABC}"
 EndProject
@@ -58,6 +60,10 @@ Global
 		{B2C3D4E5-F6A7-8901-BCDE-F123456789AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B2C3D4E5-F6A7-8901-BCDE-F123456789AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B2C3D4E5-F6A7-8901-BCDE-F123456789AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5F6A7B8-C9D0-1234-EF56-789ABCDE0123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5F6A7B8-C9D0-1234-EF56-789ABCDE0123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5F6A7B8-C9D0-1234-EF56-789ABCDE0123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5F6A7B8-C9D0-1234-EF56-789ABCDE0123}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C3D4E5F6-A7B8-9012-CDEF-123456789ABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C3D4E5F6-A7B8-9012-CDEF-123456789ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C3D4E5F6-A7B8-9012-CDEF-123456789ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -76,6 +82,7 @@ Global
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{D1CF3283-A165-477B-A08A-BEBFCD7A7712} = {9F4FA7B3-9ADD-4601-8EC7-8C9A7BD691C7}
 		{B2C3D4E5-F6A7-8901-BCDE-F123456789AB} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567891}
+		{E5F6A7B8-C9D0-1234-EF56-789ABCDE0123} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567891}
 		{C3D4E5F6-A7B8-9012-CDEF-123456789ABC} = {9F4FA7B3-9ADD-4601-8EC7-8C9A7BD691C7}
 		{D4E5F6A7-B8C9-0123-DEF1-23456789ABCD} = {1EBF655C-A427-41E1-8BFC-6A2429B7EF6E}
 	EndGlobalSection

--- a/app/Sentinel.NLogViewer.App/App.xaml.cs
+++ b/app/Sentinel.NLogViewer.App/App.xaml.cs
@@ -16,16 +16,20 @@ namespace Sentinel.NLogViewer.App
     {
         private IHost? _host;
 
+#if DEBUG
+        private TestLoggingService? _testLoggingService;
+#endif
+
         public App()
         {
             // Build the host with dependency injection
             var hostBuilder = Host.CreateApplicationBuilder();
-            
+
             // Register services
             ConfigureServices(hostBuilder.Services);
-            
+
             _host = hostBuilder.Build();
-            
+
             // Initialize localization service BEFORE XAML is loaded
             // This ensures the correct culture is set for resource loading
             var localizationService = _host.Services.GetRequiredService<LocalizationService>();
@@ -42,31 +46,37 @@ namespace Sentinel.NLogViewer.App
             services.AddSingleton<LocalizationService>();
             services.AddSingleton<TextFileFormatDetector>();
             services.AddSingleton<TextFileFormatConfigService>();
-            
+
             // Register services as scoped (one per window/view)
             services.AddScoped<UdpLogReceiverService>();
             services.AddScoped<LogFileParserService>();
-            
+
             // Register parsers as transient (new instance each time)
             services.AddTransient<Parsers.Log4JEventParser>();
             services.AddTransient<Parsers.PlainTextParser>();
             services.AddTransient<Parsers.JsonLogParser>();
-            
+
             // Register ViewModels as scoped
             services.AddScoped<MainViewModel>();
             services.AddScoped<SettingsViewModel>();
             services.AddScoped<LanguageSelectionViewModel>();
-            
+
             // Register Windows as transient (new window each time)
             services.AddTransient<MainWindow>();
             services.AddTransient<SettingsWindow>();
             services.AddTransient<LanguageSelectionWindow>();
+
+#if DEBUG
+            services.AddSingleton<TestLoggingService>();
+            services.AddTransient<TestLoggingViewModel>();
+            services.AddTransient<TestLoggingWindow>();
+#endif
         }
 
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
-            
+
             // Create and show the main window using DI
             // Create a scope for the main window and its dependencies
             if (_host != null)
@@ -74,16 +84,50 @@ namespace Sentinel.NLogViewer.App
                 var scope = _host.Services.CreateScope();
                 var mainWindow = scope.ServiceProvider.GetRequiredService<MainWindow>();
                 MainWindow = mainWindow;
-                
+
                 // Store the scope so it's disposed when the window closes
                 mainWindow.Closed += (s, args) => scope.Dispose();
-                
+
                 mainWindow.Show();
+
+#if DEBUG
+                _testLoggingService = _host.Services.GetRequiredService<TestLoggingService>();
+                if (ShouldAutoStartTestLogging())
+                {
+                    _testLoggingService.Start(new Sentinel.NLogViewer.TestLogging.TestLoggingOptions
+                    {
+                        TargetName = "chainsaw",
+                        UdpHost = "127.0.0.1",
+                        UdpPort = 4000,
+                        MessageIntervalMs = 1000,
+                        ExceptionProbability = 0.2
+                    });
+                }
+#endif
             }
         }
 
+#if DEBUG
+        private bool ShouldAutoStartTestLogging()
+        {
+            if (_host == null) return false;
+            try
+            {
+                var configService = _host.Services.GetRequiredService<ConfigurationService>();
+                return configService.LoadConfiguration().AutoStartTestLogging;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+#endif
+
         protected override void OnExit(ExitEventArgs e)
         {
+#if DEBUG
+            _testLoggingService?.Stop();
+#endif
             // Dispose the host and all registered services
             _host?.Dispose();
             base.OnExit(e);

--- a/app/Sentinel.NLogViewer.App/MainWindow.xaml
+++ b/app/Sentinel.NLogViewer.App/MainWindow.xaml
@@ -32,7 +32,7 @@
         </Grid.RowDefinitions>
         
         <!-- Menu Bar -->
-        <Menu Grid.Row="0">
+        <Menu x:Name="MainMenu" Grid.Row="0">
             <MenuItem Header="{helpers:Resource Key=Menu_File, DefaultValue=_File}">
                 <MenuItem Header="{helpers:Resource Key=Menu_OpenFile, DefaultValue=_Open File...}" 
                           Command="{Binding OpenFileCommand}" 

--- a/app/Sentinel.NLogViewer.App/MainWindow.xaml.cs
+++ b/app/Sentinel.NLogViewer.App/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Sentinel.NLogViewer.App.ViewModels;
@@ -19,16 +20,37 @@ namespace Sentinel.NLogViewer.App
             _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
             InitializeComponent();
             DataContext = _viewModel;
-            
+
             // Set window title with version
             SetWindowTitleWithVersion();
-            
+
             // Setup keyboard shortcuts
-            this.InputBindings.Add(new KeyBinding(_viewModel.OpenFileCommand, 
+            this.InputBindings.Add(new KeyBinding(_viewModel.OpenFileCommand,
                 new KeyGesture(Key.O, ModifierKeys.Control)));
-            this.InputBindings.Add(new KeyBinding(_viewModel.OpenSettingsCommand, 
+            this.InputBindings.Add(new KeyBinding(_viewModel.OpenSettingsCommand,
                 new KeyGesture(Key.OemComma, ModifierKeys.Control)));
+
+#if DEBUG
+            AddDebugMenu();
+#endif
         }
+
+#if DEBUG
+        private void AddDebugMenu()
+        {
+            var testLoggingItem = new MenuItem { Header = "_Test logging" };
+            testLoggingItem.Click += (s, _) =>
+            {
+                using var scope = App.ServiceProvider!.CreateScope();
+                var window = scope.ServiceProvider.GetRequiredService<TestLoggingWindow>();
+                window.Owner = this;
+                window.Show();
+            };
+            var debugMenu = new MenuItem { Header = "_Debug" };
+            debugMenu.Items.Add(testLoggingItem);
+            MainMenu.Items.Insert(MainMenu.Items.Count - 1, debugMenu);
+        }
+#endif
 
         /// <summary>
         /// Sets the window title with the application version

--- a/app/Sentinel.NLogViewer.App/Sentinel.NLogViewer.App.csproj
+++ b/app/Sentinel.NLogViewer.App/Sentinel.NLogViewer.App.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="NLog" Version="5.2.4" />
+    <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="SharpVectors" Version="1.8.5" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
@@ -42,6 +42,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\ui\Sentinel.NLogViewer.Wpf\Sentinel.NLogViewer.Wpf.csproj" />
+    <ProjectReference Include="..\Sentinel.NLogViewer.TestLogging\Sentinel.NLogViewer.TestLogging.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/app/Sentinel.NLogViewer.App/Services/ConfigurationService.cs
+++ b/app/Sentinel.NLogViewer.App/Services/ConfigurationService.cs
@@ -52,7 +52,8 @@ namespace Sentinel.NLogViewer.App.Services
                 Ports = new List<string> { "udp://0.0.0.0:4000" },
                 Language = string.Empty, // Empty means auto-detect on first start
                 MaxLogEntriesPerTab = 10000,
-                AutoStartListening = false
+                AutoStartListening = false,
+                AutoStartTestLogging = false
             };
         }
 
@@ -79,5 +80,8 @@ namespace Sentinel.NLogViewer.App.Services
         public string Language { get; set; } = string.Empty; // Empty means auto-detect
         public int MaxLogEntriesPerTab { get; set; } = 10000;
         public bool AutoStartListening { get; set; } = false;
+
+        /// <summary>When true (Debug only), auto-start the test log generator on startup.</summary>
+        public bool AutoStartTestLogging { get; set; } = false;
     }
 }

--- a/app/Sentinel.NLogViewer.App/Services/TestLoggingService.cs
+++ b/app/Sentinel.NLogViewer.App/Services/TestLoggingService.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel;
+using Sentinel.NLogViewer.TestLogging;
+
+namespace Sentinel.NLogViewer.App.Services;
+
+/// <summary>
+/// Holds and controls the test log generator runner for the debug panel and optional auto-start.
+/// </summary>
+public sealed class TestLoggingService : INotifyPropertyChanged
+{
+    private TestLogGeneratorRunner? _runner;
+
+    /// <summary>Whether the test log generator is currently running.</summary>
+    public bool IsRunning => _runner?.IsRunning ?? false;
+
+    /// <summary>Total normal messages generated (0 if not running).</summary>
+    public int MessageCount => _runner?.MessageCount ?? 0;
+
+    /// <summary>Total exception logs generated (0 if not running).</summary>
+    public int ExceptionCount => _runner?.ExceptionCount ?? 0;
+
+    /// <summary>
+    /// Starts the test log generator with the given options. Stops any existing runner first.
+    /// </summary>
+    public void Start(TestLoggingOptions options)
+    {
+        if (options == null)
+            throw new ArgumentNullException(nameof(options));
+
+        Stop();
+        _runner = new TestLogGeneratorRunner(options);
+        _runner.CountsChanged += OnCountsChanged;
+        _runner.Start();
+        OnPropertyChanged(nameof(IsRunning));
+        OnPropertyChanged(nameof(MessageCount));
+        OnPropertyChanged(nameof(ExceptionCount));
+    }
+
+    /// <summary>Stops and disposes the current runner.</summary>
+    public void Stop()
+    {
+        if (_runner == null) return;
+        _runner.CountsChanged -= OnCountsChanged;
+        _runner.Dispose();
+        _runner = null;
+        OnPropertyChanged(nameof(IsRunning));
+        OnPropertyChanged(nameof(MessageCount));
+        OnPropertyChanged(nameof(ExceptionCount));
+    }
+
+    private void OnCountsChanged(object? sender, EventArgs e)
+    {
+        OnPropertyChanged(nameof(MessageCount));
+        OnPropertyChanged(nameof(ExceptionCount));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged(string propertyName) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/app/Sentinel.NLogViewer.App/TestLoggingWindow.xaml
+++ b/app/Sentinel.NLogViewer.App/TestLoggingWindow.xaml
@@ -1,0 +1,81 @@
+<Window x:Class="Sentinel.NLogViewer.App.TestLoggingWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:viewModels="clr-namespace:Sentinel.NLogViewer.App.ViewModels"
+        mc:Ignorable="d"
+        Title="Test Logging (Debug)"
+        Height="380"
+        Width="400"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize"
+        d:DataContext="{d:DesignInstance viewModels:TestLoggingViewModel}">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <GroupBox Header="Parameters" Grid.Row="0" Margin="0,0,0,10">
+            <Grid Margin="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="NLog target:" VerticalAlignment="Center" Margin="0,4" />
+                <ComboBox Grid.Row="0" Grid.Column="1" Margin="0,4"
+                          ItemsSource="{Binding TargetNames}"
+                          SelectedItem="{Binding TargetName, UpdateSourceTrigger=PropertyChanged}"
+                          IsEditable="True"
+                          MinWidth="120" />
+
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="UDP host:" VerticalAlignment="Center" Margin="0,4" />
+                <TextBox Grid.Row="1" Grid.Column="1" Margin="0,4" Padding="4,2"
+                         Text="{Binding UdpHost, UpdateSourceTrigger=PropertyChanged}" />
+
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="UDP port:" VerticalAlignment="Center" Margin="0,4" />
+                <TextBox Grid.Row="2" Grid.Column="1" Margin="0,4" Padding="4,2"
+                         Text="{Binding UdpPort, UpdateSourceTrigger=PropertyChanged}" />
+
+                <TextBlock Grid.Row="3" Grid.Column="0" Text="Interval (ms):" VerticalAlignment="Center" Margin="0,4" />
+                <TextBox Grid.Row="3" Grid.Column="1" Margin="0,4" Padding="4,2"
+                         Text="{Binding MessageIntervalMs, UpdateSourceTrigger=PropertyChanged}" />
+
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Exception % (0-100):" VerticalAlignment="Center" Margin="0,4" />
+                <TextBox Grid.Row="4" Grid.Column="1" Margin="0,4" Padding="4,2"
+                         Text="{Binding ExceptionProbabilityPercent, UpdateSourceTrigger=PropertyChanged}" />
+            </Grid>
+        </GroupBox>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
+            <Button Content="Start" Command="{Binding StartCommand}" Padding="12,6" Margin="0,0,8,0" />
+            <Button Content="Stop" Command="{Binding StopCommand}" Padding="12,6" />
+        </StackPanel>
+
+        <TextBlock Grid.Row="2" Margin="0,0,0,4">
+            <Run Text="Status: " FontWeight="SemiBold" />
+            <Run Text="{Binding StatusText, Mode=OneWay}" />
+        </TextBlock>
+        <TextBlock Grid.Row="3" Margin="0,0,0,4">
+            <Run Text="Messages: " />
+            <Run Text="{Binding MessageCount, Mode=OneWay}" FontWeight="SemiBold" />
+        </TextBlock>
+        <TextBlock Grid.Row="4" Margin="0,0,0,4">
+            <Run Text="Exceptions: " />
+            <Run Text="{Binding ExceptionCount, Mode=OneWay}" FontWeight="SemiBold" />
+        </TextBlock>
+    </Grid>
+</Window>

--- a/app/Sentinel.NLogViewer.App/TestLoggingWindow.xaml.cs
+++ b/app/Sentinel.NLogViewer.App/TestLoggingWindow.xaml.cs
@@ -1,0 +1,16 @@
+using System.Windows;
+using Sentinel.NLogViewer.App.ViewModels;
+
+namespace Sentinel.NLogViewer.App;
+
+/// <summary>
+/// Debug-only window for configuring and controlling the test log generator.
+/// </summary>
+public partial class TestLoggingWindow : Window
+{
+    public TestLoggingWindow(TestLoggingViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel ?? throw new System.ArgumentNullException(nameof(viewModel));
+    }
+}

--- a/app/Sentinel.NLogViewer.App/ViewModels/TestLoggingViewModel.cs
+++ b/app/Sentinel.NLogViewer.App/ViewModels/TestLoggingViewModel.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Windows.Input;
+using Sentinel.NLogViewer.App.Services;
+using Sentinel.NLogViewer.TestLogging;
+using Sentinel.NLogViewer.Wpf;
+
+namespace Sentinel.NLogViewer.App.ViewModels;
+
+/// <summary>
+/// ViewModel for the debug Test Logging panel: options and Start/Stop commands.
+/// </summary>
+public sealed class TestLoggingViewModel : INotifyPropertyChanged
+{
+    private readonly TestLoggingService _service;
+    private string _targetName = "chainsaw";
+    private string _udpHost = "127.0.0.1";
+    private int _udpPort = 4000;
+    private int _messageIntervalMs = 1000;
+    private double _exceptionProbability = 0.2;
+
+    /// <summary>Available NLog target names for the dropdown.</summary>
+    public IReadOnlyList<string> TargetNames { get; } = new[] { "chainsaw", "log4jxml" };
+
+    public TestLoggingViewModel(TestLoggingService service)
+    {
+        _service = service ?? throw new ArgumentNullException(nameof(service));
+        StartCommand = new RelayCommand(Start, () => !_service.IsRunning);
+        StopCommand = new RelayCommand(Stop, () => _service.IsRunning);
+
+        _service.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName is nameof(TestLoggingService.IsRunning) or nameof(TestLoggingService.MessageCount) or nameof(TestLoggingService.ExceptionCount))
+            {
+                OnPropertyChanged(e.PropertyName);
+                OnPropertyChanged(nameof(StatusText));
+                ((RelayCommand)StartCommand).RaiseCanExecuteChanged();
+                ((RelayCommand)StopCommand).RaiseCanExecuteChanged();
+            }
+        };
+    }
+
+    public string TargetName
+    {
+        get => _targetName;
+        set { _targetName = value ?? "chainsaw"; OnPropertyChanged(nameof(TargetName)); }
+    }
+
+    public string UdpHost
+    {
+        get => _udpHost;
+        set { _udpHost = value ?? "127.0.0.1"; OnPropertyChanged(nameof(UdpHost)); }
+    }
+
+    public int UdpPort
+    {
+        get => _udpPort;
+        set { _udpPort = value; OnPropertyChanged(nameof(UdpPort)); }
+    }
+
+    public int MessageIntervalMs
+    {
+        get => _messageIntervalMs;
+        set { _messageIntervalMs = value; OnPropertyChanged(nameof(MessageIntervalMs)); }
+    }
+
+    public double ExceptionProbability
+    {
+        get => _exceptionProbability;
+        set { _exceptionProbability = value; OnPropertyChanged(nameof(ExceptionProbability)); OnPropertyChanged(nameof(ExceptionProbabilityPercent)); }
+    }
+
+    /// <summary>Exception probability as percentage 0-100 for UI binding.</summary>
+    public string ExceptionProbabilityPercent
+    {
+        get => ((int)(_exceptionProbability * 100)).ToString();
+        set
+        {
+            if (int.TryParse(value, out var pct))
+            {
+                _exceptionProbability = Math.Clamp(pct / 100.0, 0, 1);
+                OnPropertyChanged(nameof(ExceptionProbability));
+            }
+            OnPropertyChanged(nameof(ExceptionProbabilityPercent));
+        }
+    }
+
+    /// <summary>Status text for the panel.</summary>
+    public string StatusText => _service.IsRunning ? "Running" : "Stopped";
+
+    public bool IsRunning => _service.IsRunning;
+    public int MessageCount => _service.MessageCount;
+    public int ExceptionCount => _service.ExceptionCount;
+
+    public ICommand StartCommand { get; }
+    public ICommand StopCommand { get; }
+
+    private void Start()
+    {
+        var options = new TestLoggingOptions
+        {
+            TargetName = TargetName,
+            UdpHost = UdpHost,
+            UdpPort = UdpPort,
+            MessageIntervalMs = MessageIntervalMs,
+            ExceptionProbability = Math.Clamp(ExceptionProbability, 0, 1)
+        };
+        _service.Start(options);
+    }
+
+    private void Stop() => _service.Stop();
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged(string propertyName) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/app/Sentinel.NLogViewer.App/appsettings.json
+++ b/app/Sentinel.NLogViewer.App/appsettings.json
@@ -4,6 +4,7 @@
   ],
   "Language": "en",
   "MaxLogEntriesPerTab": 10000,
-  "AutoStartListening": false
+  "AutoStartListening": false,
+  "AutoStartTestLogging": false
 }
 

--- a/app/Sentinel.NLogViewer.TestLogging/NLogTestLoggingConfig.cs
+++ b/app/Sentinel.NLogViewer.TestLogging/NLogTestLoggingConfig.cs
@@ -1,0 +1,36 @@
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+
+namespace Sentinel.NLogViewer.TestLogging;
+
+/// <summary>
+/// Applies NLog configuration for test logging: UDP target (Log4JXml, compatible with Chainsaw/NLogViewer) with configurable address.
+/// </summary>
+public static class NLogTestLoggingConfig
+{
+    private const string TargetName = "testlog";
+
+    /// <summary>
+    /// Configures NLog to use the specified target (chainsaw or log4jxml) sending to the given UDP address.
+    /// Both names use Log4JXmlTarget (NLog 6); Replaces existing rules so only this target is used for the test logger.
+    /// </summary>
+    public static void Apply(TestLoggingOptions options)
+    {
+        if (options == null)
+            throw new ArgumentNullException(nameof(options));
+
+        var config = new LoggingConfiguration();
+        var address = options.UdpAddress;
+
+        var target = new Log4JXmlTarget
+        {
+            Name = TargetName,
+            Address = address
+        };
+
+        config.AddRule(LogLevel.Trace, LogLevel.Fatal, target);
+        LogManager.Configuration = config;
+        LogManager.ReconfigExistingLoggers();
+    }
+}

--- a/app/Sentinel.NLogViewer.TestLogging/Sentinel.NLogViewer.TestLogging.csproj
+++ b/app/Sentinel.NLogViewer.TestLogging/Sentinel.NLogViewer.TestLogging.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Sentinel.NLogViewer.TestLogging</RootNamespace>
+    <AssemblyName>Sentinel.NLogViewer.TestLogging</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="6.0.0" />
+    <PackageReference Include="NLog.Targets.Network" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/app/Sentinel.NLogViewer.TestLogging/TestLogGeneratorRunner.cs
+++ b/app/Sentinel.NLogViewer.TestLogging/TestLogGeneratorRunner.cs
@@ -1,0 +1,89 @@
+using System.Threading;
+
+namespace Sentinel.NLogViewer.TestLogging;
+
+/// <summary>
+/// Runs the test log generator: applies NLog config and a timer that generates log messages at a configurable interval.
+/// </summary>
+public sealed class TestLogGeneratorRunner : IDisposable
+{
+    private readonly TestLoggingOptions _options;
+    private readonly Random _random = new();
+    private Timer? _timer;
+    private int _messageCounter;
+    private int _exceptionCounter;
+    private bool _disposed;
+
+    /// <summary>Total number of normal log messages generated.</summary>
+    public int MessageCount => _messageCounter;
+
+    /// <summary>Total number of exception log messages generated.</summary>
+    public int ExceptionCount => _exceptionCounter;
+
+    /// <summary>Whether the runner is currently generating logs.</summary>
+    public bool IsRunning => _timer != null;
+
+    /// <summary>Raised when message or exception counts change (optional for UI).</summary>
+    public event EventHandler? CountsChanged;
+
+    public TestLogGeneratorRunner(TestLoggingOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>
+    /// Applies NLog config and starts the timer. Idempotent: if already running, does nothing.
+    /// </summary>
+    public void Start()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(TestLogGeneratorRunner));
+        if (_timer != null)
+            return;
+
+        NLogTestLoggingConfig.Apply(_options);
+        var intervalMs = Math.Max(1, _options.MessageIntervalMs);
+        _timer = new Timer(OnTick, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(intervalMs));
+    }
+
+    /// <summary>
+    /// Stops the timer. Idempotent.
+    /// </summary>
+    public void Stop()
+    {
+        var t = Interlocked.Exchange(ref _timer, null);
+        t?.Dispose();
+    }
+
+    private void OnTick(object? state)
+    {
+        try
+        {
+            var totalCount = _messageCounter + _exceptionCounter;
+            var isException = TestLogMessageGenerator.GenerateOne(
+                _random,
+                totalCount,
+                Math.Clamp(_options.ExceptionProbability, 0, 1));
+
+            if (isException)
+                Interlocked.Increment(ref _exceptionCounter);
+            else
+                Interlocked.Increment(ref _messageCounter);
+
+            CountsChanged?.Invoke(this, EventArgs.Empty);
+        }
+        catch
+        {
+            // Avoid crashing the timer; ignore generation errors
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        Stop();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/app/Sentinel.NLogViewer.TestLogging/TestLogMessageGenerator.cs
+++ b/app/Sentinel.NLogViewer.TestLogging/TestLogMessageGenerator.cs
@@ -1,0 +1,121 @@
+using NLog;
+
+namespace Sentinel.NLogViewer.TestLogging;
+
+/// <summary>
+/// Generates random log messages and exception logs for test logging (no console output).
+/// </summary>
+public static class TestLogMessageGenerator
+{
+    private static readonly string[] LoggerNames =
+    {
+        "Sentinel.NLogViewer.TestLogging",
+        "Sentinel.NLogViewer.App.Services",
+        "Sentinel.NLogViewer.App.Services.DataService",
+        "Sentinel.NLogViewer.App.Services.NetworkService",
+        "Sentinel.NLogViewer.App.Controllers",
+        "Sentinel.NLogViewer.App.Controllers.HomeController",
+        "Sentinel.NLogViewer.App.Models",
+        "Sentinel.NLogViewer.App.Utils"
+    };
+
+    private static readonly string[] Messages =
+    {
+        "Application started successfully",
+        "Processing user request",
+        "Database connection established",
+        "Cache updated with new data",
+        "Configuration loaded from file",
+        "User authentication successful",
+        "File uploaded successfully",
+        "Background task completed",
+        "Memory usage: {0} MB",
+        "CPU usage: {0}%",
+        "Network request sent to {0}",
+        "Response received in {0}ms",
+        "Validation passed for user input",
+        "Session created for user {0}",
+        "Data synchronized with server"
+    };
+
+    private static readonly LogLevel[] LogLevels =
+    {
+        LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal
+    };
+
+    /// <summary>
+    /// Generates one log message (normal or exception based on exceptionProbability) and returns true if it was an exception log.
+    /// </summary>
+    public static bool GenerateOne(Random random, int messageCounter, double exceptionProbability)
+    {
+        if (random == null)
+            throw new ArgumentNullException(nameof(random));
+
+        bool isException = exceptionProbability > 0 && random.NextDouble() < exceptionProbability;
+        if (isException)
+            GenerateExceptionLog(random);
+        else
+            GenerateNormalLog(random, messageCounter);
+        return isException;
+    }
+
+    private static void GenerateNormalLog(Random random, int messageCounter)
+    {
+        var logLevel = LogLevels[random.Next(LogLevels.Length)];
+        var message = GenerateRandomMessage(random, messageCounter);
+        var loggerName = LoggerNames[random.Next(LoggerNames.Length)];
+        var logger = LogManager.GetLogger(loggerName);
+
+        switch (logLevel.Name)
+        {
+            case "Trace": logger.Trace(message); break;
+            case "Debug": logger.Debug(message); break;
+            case "Info": logger.Info(message); break;
+            case "Warn": logger.Warn(message); break;
+            case "Error": logger.Error(message); break;
+            case "Fatal": logger.Fatal(message); break;
+            default: logger.Info(message); break;
+        }
+    }
+
+    private static void GenerateExceptionLog(Random random)
+    {
+        var exceptionType = random.Next(1, 4);
+        Exception exception;
+        LogLevel logLevel;
+
+        switch (exceptionType)
+        {
+            case 1:
+                exception = new InvalidOperationException($"Invalid operation occurred at {DateTime.Now:HH:mm:ss}");
+                logLevel = LogLevel.Error;
+                break;
+            case 2:
+                exception = new ArgumentNullException("testParameter", "Test parameter was null");
+                logLevel = LogLevel.Error;
+                break;
+            case 3:
+                exception = new DivideByZeroException("Division by zero attempted");
+                logLevel = LogLevel.Fatal;
+                break;
+            default:
+                exception = new Exception("Generic exception occurred");
+                logLevel = LogLevel.Error;
+                break;
+        }
+
+        var logger = LogManager.GetLogger(LoggerNames[random.Next(LoggerNames.Length)]);
+
+        if (logLevel == LogLevel.Fatal)
+            logger.Fatal(exception, $"Fatal exception: {exception.Message}");
+        else
+            logger.Error(exception, $"Error exception: {exception.Message}");
+    }
+
+    private static string GenerateRandomMessage(Random random, int messageCounter)
+    {
+        var message = Messages[random.Next(Messages.Length)];
+        message = message.Replace("{0}", random.Next(1, 100).ToString());
+        return $"{message} (Message #{messageCounter + 1})";
+    }
+}

--- a/app/Sentinel.NLogViewer.TestLogging/TestLoggingOptions.cs
+++ b/app/Sentinel.NLogViewer.TestLogging/TestLoggingOptions.cs
@@ -1,0 +1,25 @@
+namespace Sentinel.NLogViewer.TestLogging;
+
+/// <summary>
+/// Options for the test log generator (NLog target, UDP address, interval, exception probability).
+/// </summary>
+public class TestLoggingOptions
+{
+    /// <summary>NLog target name: "chainsaw" or "log4jxml".</summary>
+    public string TargetName { get; set; } = "chainsaw";
+
+    /// <summary>UDP host (e.g. 127.0.0.1).</summary>
+    public string UdpHost { get; set; } = "127.0.0.1";
+
+    /// <summary>UDP port (e.g. 4000).</summary>
+    public int UdpPort { get; set; } = 4000;
+
+    /// <summary>Message generation interval in milliseconds.</summary>
+    public int MessageIntervalMs { get; set; } = 1000;
+
+    /// <summary>Probability of generating an exception log (0.0 to 1.0).</summary>
+    public double ExceptionProbability { get; set; } = 0.2;
+
+    /// <summary>UDP address string for NLog (udp://host:port).</summary>
+    public string UdpAddress => $"udp://{UdpHost}:{UdpPort}";
+}

--- a/testapp/Sentinel.NLogViewer.App.TestApp/Program.cs
+++ b/testapp/Sentinel.NLogViewer.App.TestApp/Program.cs
@@ -1,216 +1,47 @@
-﻿using System;
-using System.Threading;
+using System;
 using System.Threading.Tasks;
 using NLog;
+using Sentinel.NLogViewer.TestLogging;
 
-namespace Sentinel.NLogViewer.App.TestApp
+namespace Sentinel.NLogViewer.App.TestApp;
+
+/// <summary>
+/// Console test app: runs the shared test log generator until a key is pressed.
+/// </summary>
+internal static class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-        private static readonly Random Random = new Random();
-        private static Timer? _logTimer;
-        private static int _messageCounter = 0;
-        private static int _exceptionCounter = 0;
+        Console.WriteLine("NLogViewer Client Application Test App");
+        var nlogVersion = typeof(LogManager).Assembly.GetName().Version;
+        Console.WriteLine($"NLog Version: {nlogVersion}");
 
-        static async Task Main(string[] args)
+        var targetName = Environment.GetEnvironmentVariable("NLOG_TARGET") ?? "chainsaw";
+        Console.WriteLine($"Using target: {targetName}");
+        Console.WriteLine("Press any key to stop logging...");
+        Console.WriteLine();
+
+        var options = new TestLoggingOptions
         {
-            Console.WriteLine("NLogViewer Client Application Test App");
-            var nlogVersion = typeof(LogManager).Assembly.GetName().Version;
-            Console.WriteLine($"NLog Version: {nlogVersion}");
-            
-            // Check which target to use from environment variable
-            var targetName = Environment.GetEnvironmentVariable("NLOG_TARGET") ?? "chainsaw";
-            Console.WriteLine($"Using target: {targetName}");
-            Console.WriteLine("Press any key to stop logging...");
-            Console.WriteLine();
-            
-            // Update NLog configuration to use the specified target
-            UpdateNLogTarget(targetName);
+            TargetName = targetName,
+            UdpHost = "127.0.0.1",
+            UdpPort = 4000,
+            MessageIntervalMs = 1000,
+            ExceptionProbability = 0.2
+        };
 
-            // Start logging timer
-            _logTimer = new Timer(GenerateLogMessage, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        using var runner = new TestLogGeneratorRunner(options);
+        runner.Start();
 
-            // Wait for user input
-            await Task.Run(() => Console.ReadKey(true));
+        await Task.Run(() => Console.ReadKey(true));
 
-            // Stop timer
-            _logTimer?.Dispose();
-            
-            Console.WriteLine();
-            Console.WriteLine($"Total messages logged: {_messageCounter}");
-            Console.WriteLine($"Total exceptions logged: {_exceptionCounter}");
-            Console.WriteLine("Shutting down...");
+        runner.Stop();
 
-            LogManager.Shutdown();
-        }
+        Console.WriteLine();
+        Console.WriteLine($"Total messages logged: {runner.MessageCount}");
+        Console.WriteLine($"Total exceptions logged: {runner.ExceptionCount}");
+        Console.WriteLine("Shutting down...");
 
-        private static void UpdateNLogTarget(string targetName)
-        {
-            try
-            {
-                var config = LogManager.Configuration;
-                if (config == null) return;
-
-                // Remove existing rules
-                config.LoggingRules.Clear();
-
-                // Add new rule with specified target
-                var target = config.FindTargetByName(targetName);
-                if (target != null)
-                {
-                    config.LoggingRules.Add(new NLog.Config.LoggingRule("*", NLog.LogLevel.Trace, target));
-                    LogManager.Configuration = config;
-                    LogManager.ReconfigExistingLoggers();
-                    Console.WriteLine($"Successfully configured NLog to use target: {targetName}");
-                }
-                else
-                {
-                    Console.WriteLine($"Warning: Target '{targetName}' not found. Using default configuration.");
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error updating NLog target: {ex.Message}");
-            }
-        }
-
-        private static void GenerateLogMessage(object? state)
-        {
-            try
-            {
-                // 20% chance to generate an exception
-                if (Random.Next(1, 6) == 1)
-                {
-                    GenerateExceptionLog();
-                }
-                else
-                {
-                    GenerateNormalLog();
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error generating log message: {ex.Message}");
-            }
-        }
-
-        private static void GenerateNormalLog()
-        {
-            var logLevel = GetRandomLogLevel();
-            var message = GenerateRandomMessage();
-            var loggerName = GetRandomLoggerName();
-
-            var logger = LogManager.GetLogger(loggerName);
-
-            if (logLevel == LogLevel.Trace)
-                logger.Trace(message);
-            else if (logLevel == LogLevel.Debug)
-                logger.Debug(message);
-            else if (logLevel == LogLevel.Info)
-                logger.Info(message);
-            else if (logLevel == LogLevel.Warn)
-                logger.Warn(message);
-            else if (logLevel == LogLevel.Error)
-                logger.Error(message);
-            else if (logLevel == LogLevel.Fatal)
-                logger.Fatal(message);
-
-            Interlocked.Increment(ref _messageCounter);
-            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {logLevel.Name}: {message}");
-        }
-
-        private static void GenerateExceptionLog()
-        {
-            var exceptionType = Random.Next(1, 4);
-            Exception exception;
-            LogLevel logLevel;
-
-            switch (exceptionType)
-            {
-                case 1:
-                    exception = new InvalidOperationException($"Invalid operation occurred at {DateTime.Now:HH:mm:ss}");
-                    logLevel = LogLevel.Error;
-                    break;
-                case 2:
-                    exception = new ArgumentNullException("testParameter", "Test parameter was null");
-                    logLevel = LogLevel.Error;
-                    break;
-                case 3:
-                    exception = new DivideByZeroException("Division by zero attempted");
-                    logLevel = LogLevel.Fatal;
-                    break;
-                default:
-                    exception = new Exception("Generic exception occurred");
-                    logLevel = LogLevel.Error;
-                    break;
-            }
-
-            var logger = LogManager.GetLogger(GetRandomLoggerName());
-            
-            if (logLevel == LogLevel.Fatal)
-            {
-                logger.Fatal(exception, $"Fatal exception: {exception.Message}");
-            }
-            else
-            {
-                logger.Error(exception, $"Error exception: {exception.Message}");
-            }
-
-            Interlocked.Increment(ref _exceptionCounter);
-            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {logLevel.Name} (Exception): {exception.GetType().Name} - {exception.Message}");
-        }
-
-        private static LogLevel GetRandomLogLevel()
-        {
-            var levels = new[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal };
-            return levels[Random.Next(levels.Length)];
-        }
-
-        private static string GenerateRandomMessage()
-        {
-            var messages = new[]
-            {
-                "Application started successfully",
-                "Processing user request",
-                "Database connection established",
-                "Cache updated with new data",
-                "Configuration loaded from file",
-                "User authentication successful",
-                "File uploaded successfully",
-                "Background task completed",
-                "Memory usage: {0} MB",
-                "CPU usage: {0}%",
-                "Network request sent to {0}",
-                "Response received in {0}ms",
-                "Validation passed for user input",
-                "Session created for user {0}",
-                "Data synchronized with server"
-            };
-
-            var message = messages[Random.Next(messages.Length)];
-            
-            // Replace placeholders with random values
-            message = message.Replace("{0}", Random.Next(1, 100).ToString());
-            
-            return $"{message} (Message #{_messageCounter + 1})";
-        }
-
-        private static string GetRandomLoggerName()
-        {
-            var loggerNames = new[]
-            {
-                "Sentinel.NLogViewer.App.TestApp",
-                "Sentinel.NLogViewer.App.TestApp.Services",
-                "Sentinel.NLogViewer.App.TestApp.Services.DataService",
-                "Sentinel.NLogViewer.App.TestApp.Services.NetworkService",
-                "Sentinel.NLogViewer.App.TestApp.Controllers",
-                "Sentinel.NLogViewer.App.TestApp.Controllers.HomeController",
-                "Sentinel.NLogViewer.App.TestApp.Models",
-                "Sentinel.NLogViewer.App.TestApp.Utils"
-            };
-
-            return loggerNames[Random.Next(loggerNames.Length)];
-        }
+        LogManager.Shutdown();
     }
 }

--- a/testapp/Sentinel.NLogViewer.App.TestApp/Sentinel.NLogViewer.App.TestApp.csproj
+++ b/testapp/Sentinel.NLogViewer.App.TestApp/Sentinel.NLogViewer.App.TestApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -27,5 +27,9 @@
     <PackageReference Include="NLog" Version="6.0.0" />
     <PackageReference Include="NLog.Targets.Network" Version="6.0.0" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\app\Sentinel.NLogViewer.TestLogging\Sentinel.NLogViewer.TestLogging.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
…Test Logging panel

- Add Sentinel.NLogViewer.TestLogging project (options, NLog config, message generator, runner)
- Refactor TestApp to use shared library; keep console entry and key-to-stop behavior
- Add TestLoggingService, TestLoggingViewModel, and TestLoggingWindow in main app (DEBUG only)
- Add Debug menu with 'Test logging' item and optional AutoStartTestLogging config
- Bump main app NLog to 6.0.0 for TestLogging dependency; no functional change in Release